### PR TITLE
Update product lines list view with sorting

### DIFF
--- a/src/app/product-lines/product-lines-list-client.tsx
+++ b/src/app/product-lines/product-lines-list-client.tsx
@@ -2,7 +2,7 @@
 
 import { Badge } from "@/components/ui/badge"
 import { Package } from "lucide-react"
-import { ListView } from "@/components/ui/list-view"
+import { SortableListView } from "@/components/ui/sortable-list-view"
 import { ViewToggle } from "@/components/ui/view-toggle"
 import { useViewPreference } from "@/hooks/use-view-preference"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -16,6 +16,7 @@ interface ProductLinesListProps {
     description: string | null
     introduced_year: number | null
     discontinued_year: number | null
+    updated_at: Date | null
     manufacturers: {
       id: string
       name: string
@@ -185,12 +186,13 @@ export function ProductLinesListClient({ productLines }: ProductLinesListProps) 
       </div>
 
       {currentView === 'list' ? (
-        <ListView 
+        <SortableListView 
           data={productLines}
           fields={[
             { key: 'name', label: 'Name' },
             { key: 'manufacturer', label: 'Manufacturer', render: (item) => item.manufacturers?.name || 'Unknown' },
-            { key: 'period', label: 'Period', render: (item) => getProductionYears(item.introduced_year, item.discontinued_year) },
+            { key: 'introduced_year', label: 'First year', render: (item) => item.introduced_year || 'Unknown' },
+            { key: 'updated_at', label: 'Updated at', render: (item) => item.updated_at ? new Date(item.updated_at).toLocaleDateString() : 'Unknown' },
             { key: 'models', label: 'Models', render: (item) => `${item._count.models} model${item._count.models !== 1 ? 's' : ''}` }
           ]}
           getHref={(item) => `/product-lines/${item.id}`}

--- a/src/app/product-lines/product-lines-list.tsx
+++ b/src/app/product-lines/product-lines-list.tsx
@@ -10,6 +10,7 @@ async function getProductLines() {
         description: true,
         introduced_year: true,
         discontinued_year: true,
+        updated_at: true,
         manufacturers: {
           select: {
             id: true,

--- a/src/components/ui/sortable-list-view.tsx
+++ b/src/components/ui/sortable-list-view.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import Link from "next/link"
+import { ChevronDown, ChevronUp } from "lucide-react"
+import { useState } from "react"
+
+interface SortConfig {
+  key: string
+  direction: 'asc' | 'desc'
+}
+
+interface SortableListViewProps {
+  data: any[]
+  fields: {
+    key: string
+    label: string
+    render?: (item: any) => React.ReactNode
+    sortable?: boolean
+  }[]
+  getHref: (item: any) => string
+  emptyMessage?: string
+  emptyIcon?: React.ReactNode
+}
+
+export function SortableListView({ 
+  data, 
+  fields, 
+  getHref, 
+  emptyMessage = "No items found.", 
+  emptyIcon 
+}: SortableListViewProps) {
+  const [sortConfig, setSortConfig] = useState<SortConfig | null>(null)
+
+  const handleSort = (key: string) => {
+    let direction: 'asc' | 'desc' = 'asc'
+    
+    if (sortConfig && sortConfig.key === key && sortConfig.direction === 'asc') {
+      direction = 'desc'
+    }
+    
+    setSortConfig({ key, direction })
+  }
+
+  const sortedData = sortConfig ? [...data].sort((a, b) => {
+    const field = fields.find(f => f.key === sortConfig.key)
+    let aValue = a[sortConfig.key]
+    let bValue = b[sortConfig.key]
+    
+    // Handle nested properties (like manufacturers.name)
+    if (sortConfig.key === 'manufacturer') {
+      aValue = a.manufacturers?.name || 'Unknown'
+      bValue = b.manufacturers?.name || 'Unknown'
+    }
+    
+    // Handle null/undefined values
+    if (aValue === null || aValue === undefined) aValue = ''
+    if (bValue === null || bValue === undefined) bValue = ''
+    
+    // Handle dates
+    if (sortConfig.key === 'updated_at' || sortConfig.key === 'introduced_year') {
+      aValue = aValue ? (aValue instanceof Date ? aValue : new Date(aValue)) : new Date(0)
+      bValue = bValue ? (bValue instanceof Date ? bValue : new Date(bValue)) : new Date(0)
+    }
+    
+    // Handle numbers
+    if (sortConfig.key === 'introduced_year') {
+      aValue = aValue ? Number(aValue) : 0
+      bValue = bValue ? Number(bValue) : 0
+    }
+    
+    // Handle models count
+    if (sortConfig.key === 'models') {
+      aValue = a._count?.models || 0
+      bValue = b._count?.models || 0
+    }
+    
+    let result = 0
+    if (aValue < bValue) result = -1
+    if (aValue > bValue) result = 1
+    
+    return sortConfig.direction === 'desc' ? -result : result
+  }) : data
+
+  if (data.length === 0) {
+    return (
+      <div className="text-center py-12">
+        {emptyIcon && <div className="mb-4">{emptyIcon}</div>}
+        <p className="text-muted-foreground">{emptyMessage}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-border">
+            {fields.map((field) => (
+              <th
+                key={field.key}
+                className={`px-4 py-3 text-left text-sm font-medium text-foreground ${
+                  field.sortable !== false ? 'cursor-pointer hover:bg-muted/50 transition-colors' : ''
+                }`}
+                onClick={field.sortable !== false ? () => handleSort(field.key) : undefined}
+              >
+                <div className="flex items-center gap-1">
+                  {field.label}
+                  {field.sortable !== false && (
+                    <div className="flex flex-col">
+                      {sortConfig && sortConfig.key === field.key && sortConfig.direction === 'desc' ? (
+                        <ChevronUp className="h-4 w-4" />
+                      ) : sortConfig && sortConfig.key === field.key && sortConfig.direction === 'asc' ? (
+                        <ChevronDown className="h-4 w-4" />
+                      ) : (
+                        <ChevronDown className="h-4 w-4 opacity-30" />
+                      )}
+                    </div>
+                  )}
+                </div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sortedData.map((item) => (
+            <tr
+              key={item.id}
+              className="border-b border-border hover:bg-muted/50 transition-colors"
+            >
+              {fields.map((field, index) => (
+                <td key={field.key} className="px-4 py-4 text-sm">
+                  {index === 0 ? (
+                    <Link
+                      href={getHref(item)}
+                      className="text-primary hover:text-primary/80 font-medium"
+                    >
+                      {field.render ? field.render(item) : item[field.key]}
+                    </Link>
+                  ) : (
+                    <span className="text-foreground">
+                      {field.render ? field.render(item) : item[field.key]}
+                    </span>
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}


### PR DESCRIPTION
Update Product Lines list view by adding sortable columns 'First year' and 'Updated at', and removing 'Period' column, as per Linear issue REG-3.

---
Linear Issue: [REG-3](https://linear.app/dotsur/issue/REG-3/updates-to-product-lines-list-view)

<a href="https://cursor.com/background-agent?bcId=bc-8dce0b1b-488f-4db2-b215-c10ce60c19da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8dce0b1b-488f-4db2-b215-c10ce60c19da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

